### PR TITLE
Return result from decode & split to modules

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,5 @@
 #[cfg(feature = "python")]
 mod python;
-#[cfg(feature = "python")]
-use pyo3::{create_exception, exceptions::PyException, prelude::*, types::PyBytes};
 
 #[cfg(test)]
 #[macro_use]
@@ -28,7 +26,6 @@ impl fmt::Display for DecodeError {
     }
 }
 
-#[cfg_attr(feature = "python", pyfunction)]
 pub fn encode(input: &[u8]) -> String {
     let mut result = Vec::new();
     let chunks = input.chunks(5);
@@ -83,23 +80,6 @@ pub fn decode(input: &str) -> Result<Vec<u8>, DecodeError> {
         result.pop();
     }
     Ok(result)
-}
-
-#[cfg(feature = "python")]
-#[pymodule]
-fn zbase32(py: Python, m: &PyModule) -> PyResult<()> {
-    create_exception!(zbase32, DecodeError, PyException);
-
-    m.add_function(wrap_pyfunction!(encode, m)?)?;
-    m.add("DecodeError", py.get_type::<DecodeError>())?;
-    #[pyfn(m)]
-    fn decode<'a>(py: Python<'a>, input: &'a str) -> PyResult<&'a PyBytes> {
-        match crate::decode(input) {
-            Ok(b) => Ok(PyBytes::new(py, &b)),
-            Err(_) => Err(DecodeError::new_err("Non-zbase32 digit found")),
-        }
-    }
-    Ok(())
 }
 
 #[cfg(test)]

--- a/src/python.rs
+++ b/src/python.rs
@@ -1,0 +1,31 @@
+use pyo3::{create_exception, exceptions::PyException, prelude::*, types::PyBytes};
+
+create_exception!(zbase32, DecodeError, PyException);
+
+#[inline]
+#[pyfunction]
+#[pyo3(text_signature = "(input)")]
+/// Decode zbase32 encoded string to bytes
+fn decode<'a>(py: Python<'a>, input: &'a str) -> PyResult<&'a PyBytes> {
+    match crate::decode(input) {
+        Ok(b) => Ok(PyBytes::new(py, &b)),
+        Err(_) => Err(DecodeError::new_err("Non-zbase32 digit found")),
+    }
+}
+
+#[inline]
+#[pyfunction]
+#[pyo3(text_signature = "(input)")]
+/// Encode bytes using a zbase32 and return encoded string
+fn encode(input: &[u8]) -> String {
+    crate::encode(input)
+}
+
+#[pymodule]
+fn zbase32(py: Python, m: &PyModule) -> PyResult<()> {
+    m.add("DecodeError", py.get_type::<DecodeError>())?;
+
+    m.add_function(wrap_pyfunction!(decode, m)?)?;
+    m.add_function(wrap_pyfunction!(encode, m)?)?;
+    Ok(())
+}


### PR DESCRIPTION
- move python specific code to separate module
- raise exception if error occurred rather than return `None`
- return `Result` instead of `Option`