### PR TITLE
Accept `impl AsRef<[u8]>` in encode

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ cargo add z-base-32
 The library exposes two functions with the following signatures and an error type:
 
 ```rs
-pub fn encode(input: &[u8]) -> String;
+pub fn encode(input: impl AsRef<[u8]>) -> String;
 
 pub fn decode(input: &str) -> Result<Vec<u8>, DecodeError>;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,7 +28,8 @@ impl fmt::Display for DecodeError {
     }
 }
 
-pub fn encode(input: &[u8]) -> String {
+pub fn encode(input: impl AsRef<[u8]>) -> String {
+    let input = input.as_ref();
     let mut result = Vec::new();
     let chunks = input.chunks(5);
 
@@ -90,6 +91,17 @@ mod tests {
     #[test]
     fn simple_encode() {
         assert_eq!(encode(b"asdasd"), "cf3seamuco".to_string());
+    }
+
+    #[test]
+    fn encode_str() {
+        assert_eq!(encode("asdasd"), "cf3seamuco".to_string());
+    }
+
+    #[test]
+    fn encode_string() {
+        let string = String::from("asdasd");
+        assert_eq!(encode(string), "cf3seamuco".to_string());
     }
 
     #[test]


### PR DESCRIPTION
By using `impl AsRef<[u8]>` instead of raw `&[u8]` encode may be used with Strings and string slices directly. This is also important for foreign types as they can implement `AsRef<[u8]>` and be directly usable by `encode`.