### PR TITLE
Add documentation and fix README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,14 +28,12 @@ pub struct DecodeError;
 
 #### Example
 
-```rs
+```rust
 use zbase32::{encode, decode};
 
-fn main() {
-    assert_eq!(encode(b"foo"), "c3zs6".to_string());
-    assert_eq!(Ok(b"foo"), decode("c3zs6".to_string()));
-    assert_eq!(decode(&encode(b"foo")).unwrap(), b"foo")
-}
+assert_eq!(encode("foo"), "c3zs6");
+assert_eq!(Ok(b"foo".into()), decode("c3zs6"));
+assert_eq!(decode(&encode("foo")).unwrap(), b"foo")
 ```
 
 ### CLI

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,6 @@
+#![doc = include_str!("../README.md")]
+#![deny(missing_docs)]
+
 #[cfg(feature = "python")]
 mod python;
 
@@ -17,6 +20,7 @@ const INVERSE_ALPHABET: [i8; 123] = [
     23,
 ];
 
+/// Error decoding input bytes.
 #[derive(Debug, PartialEq)]
 pub struct DecodeError;
 
@@ -28,6 +32,15 @@ impl fmt::Display for DecodeError {
     }
 }
 
+/// Z-base32 encodes `input`.
+///
+/// # Examples
+///
+/// ```
+/// use zbase32::encode;
+///
+/// assert_eq!(encode("asdasd"), "cf3seamuco");
+/// ```
 pub fn encode(input: impl AsRef<[u8]>) -> String {
     let input = input.as_ref();
     let mut result = Vec::new();
@@ -58,6 +71,15 @@ pub fn encode(input: impl AsRef<[u8]>) -> String {
     unsafe { String::from_utf8_unchecked(result) }
 }
 
+/// Decodes z-base-32 encoded data into a vector of bytes.
+///
+/// # Examples
+///
+/// ```
+/// use zbase32::decode;
+///
+/// assert_eq!(decode("cf3seamu"), Ok(b"asdas".to_vec()))
+/// ```
 pub fn decode(input: &str) -> Result<Vec<u8>, DecodeError> {
     let mut result = Vec::new();
     for chunk in input.as_bytes().chunks(8) {


### PR DESCRIPTION
Converts a README example into a runnable test, attaches the README as a crate-level documentation. Adds a couple of bits of docs and enables "missing_docs" lint.